### PR TITLE
Prevent selection on '+# more not shown'

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ var DropdownInput = React.createClass({
       MenuItem,
       {
         key: index,
-        onSelect: this.handleOptionSelect.bind(this, index, item),
+        onSelect: disabled ? null : this.handleOptionSelect.bind(this, index, item),
         className: classes,
         onMouseEnter: this.handleMouseEnter.bind(this, index) },
       part1,

--- a/src/DropdownInput.js
+++ b/src/DropdownInput.js
@@ -153,7 +153,7 @@ var DropdownInput = React.createClass({
     return (
       <MenuItem
         key={index}
-        onSelect={this.handleOptionSelect.bind(this, index, item)}
+        onSelect={disabled ? null : this.handleOptionSelect.bind(this, index, item)}
         className={classes}
         onMouseEnter={this.handleMouseEnter.bind(this, index)}>
           {part1}<b>{part2}</b>{part3}


### PR DESCRIPTION
First of all: thanks for the library!

Anyway, I noticed that user can click on the disabled '+# more not shown' option and the text will be set into the input text. The commit in this PR is to prevent that from happening.

Best Regards,
